### PR TITLE
Update trainer.py

### DIFF
--- a/fastxml/trainer.py
+++ b/fastxml/trainer.py
@@ -217,7 +217,7 @@ class Trainer(object):
                         penalty=penalty, random_state=rs)
 
         else:
-            clf = SGDClassifier(loss=self.loss, penalty=penalty, n_iter=n_epochs, 
+            clf = SGDClassifier(loss=self.loss, penalty=penalty, max_iter=n_epochs, 
                     alpha=self.alpha, fit_intercept=self.bias, class_weight='balanced',
                     random_state=rs)
 


### PR DESCRIPTION
Changing to max_iter (or removing n_iter altogether) fixes the problem with SGDClassifier attributes. n_iter is depricated and was removed starting scikit-learn 0.21

You might also consider changing the requirements file to lock the versions to exactly what the repo works with instead of having a "library>=version " style.