### PR TITLE
Issue 34

### DIFF
--- a/fastxml/proc.py
+++ b/fastxml/proc.py
@@ -46,8 +46,10 @@ def faux_fork_call(f):
 def fork_call(f):
     def f2(*args):
         queue = multiprocessing.Queue(1)
-        p = multiprocessing.Process(target=_remote_call, args=(queue, f, args))
-        p.start()
+        ctx = multiprocessing.get_context('fork')
+        p = ctx.Process(target=_remote_call, args=(queue, f, args))
+        if __name__ == '__main__':
+            p.start()
         return ForkResult(queue, p)
 
     return f2

--- a/fastxml/trainer.py
+++ b/fastxml/trainer.py
@@ -462,7 +462,8 @@ class Trainer(object):
         return Tree(rootIdx, W_stack, b, t, probs)
 
     def fit(self, X, y, weights=None):
-        self.roots = self._build_roots(X, y, weights)
+        if __name__ == '__main__':
+            self.roots = self._build_roots(X, y, weights)
         if self.leaf_classifiers:
             self.norms_, self.uxs_, self.xr_ = self._compute_leaf_probs(X, y)
 


### PR DESCRIPTION
To solve the multiprocessing issue, we need to wrap the call to `self._build_roots(X, y, weights)` inside an `if __name__ == '__main__':` block. This ensures that the multiprocessing module works correctly when `n_jobs` is greater than one.
To solve the problem, we need to modify the `fork_call` function to use `multiprocessing.get_context('fork')` for creating the process. Additionally, we need to ensure that the process creation is wrapped in a `if __name__ == '__main__':` block to avoid the RuntimeError.